### PR TITLE
Remove game start command on Ski init

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -214,8 +214,6 @@ function startNeverEndingGame (images) {
           }
           timer.setPercent(elapsed / settings.duration)
         })
-
-        game.start()
         break
 
       case 'Suspend':


### PR DESCRIPTION
The Ski game started immediately when initialized, eating up the configured duration until started.