### PR TITLE
Lighten central LED after resume

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -223,6 +223,13 @@ function startNeverEndingGame (images) {
 
       case 'Resume':
         game.resume()
+        window.PlayEGI.led({
+          channel: 2, // center
+          symbol: 2, // plus
+          mode: 1, // on
+          color: { r: 1, g: 1, b: 1 }, // white
+          brightness: 50, // default
+        })
         break
 
       case 'Ping':


### PR DESCRIPTION
Previously, the standard LED was mode was used in ski: central orange
cross, and blue arrows. But we are making a change to disable the LEDs
before starting a game, so that the game is responsible to set up
whatever it wants.

Keeping as a draft until diviapps PR is ready.